### PR TITLE
add an option to update apt cache on package install tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+# @var redis_apt_cache_update:description: >
+# Automatically update apt cache on package installations.
+# This setting will only applied on apt-based operating systems e.g. Ubuntu.
+# @end
+redis_apt_cache_update: False
+
 # @var redis_packages:description: >
 # Define a custom list of packages to install. Default value depends
 # on your operating system.

--- a/molecule/ubuntu1804/playbook.yml
+++ b/molecule/ubuntu1804/playbook.yml
@@ -1,5 +1,8 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    redis_apt_cache_update: True
+
   roles:
     - role: redis

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -2,12 +2,14 @@
 - name: Ensure dependencies are installed
   package:
     name: "{{ item }}"
+    update_cache: "{{ redis_apt_cache_update }}"
     state: present
   loop: "{{ redis_packages_extra }}"
 
 - name: Ensure Redis is installed
   package:
     name: "{{ item }}"
+    update_cache: "{{ redis_apt_cache_update }}"
     state: present
   loop: "{{ redis_packages }}"
 


### PR DESCRIPTION
see https://github.com/owncloud-ansible/mariadb/pull/2