### PR TITLE
Redis 5 for CentOS 7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,9 @@ redis_bind_interface: "127.0.0.1"
 redis_timeout: 300
 
 redis_loglevel: "notice"
-redis_logfile: /var/log/redis/redis-server.log
+# @var redis_logfile:description: >
+# Can be used to change the redis log file path
+# @end
 
 redis_databases: 16
 
@@ -36,7 +38,9 @@ redis_save:
 
 redis_rdbcompression: "yes"
 redis_dbfilename: dump.rdb
-redis_dbdir: /var/lib/redis
+# @var redis_dbdir:description: >
+# Can be used to change the redis dbdir path
+# @end
 
 redis_maxmemory: 0
 redis_maxmemory_policy: "noeviction"

--- a/molecule/centos7/converge.yml
+++ b/molecule/centos7/converge.yml
@@ -1,5 +1,9 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+    redis_packages_extra:
+      - centos-release-scl
+
   roles:
     - role: redis

--- a/molecule/centos7/converge.yml
+++ b/molecule/centos7/converge.yml
@@ -1,9 +1,5 @@
 ---
 - name: Converge
   hosts: all
-  vars:
-    redis_packages_extra:
-      - epel-release
-
   roles:
     - role: redis

--- a/molecule/centos7/tests/test_default.py
+++ b/molecule/centos7/tests/test_default.py
@@ -8,14 +8,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_redis_running_and_enabled(host):
-    redis = host.service("redis")
+    redis = host.service("rh-redis5-redis")
 
     assert redis.is_running
     assert redis.is_enabled
 
 
 def test_redis_config(host):
-    assert "127.0.0.1" in host.run("redis-cli config get bind").stdout
-    assert "6379" in host.run("redis-cli config get port").stdout
+    assert "127.0.0.1" in host.run("/opt/rh/rh-redis5/root/usr/bin/redis-cli config get bind").stdout
+    assert "6379" in host.run("/opt/rh/rh-redis5/root/usr/bin/redis-cli config get port").stdout
 
-    assert "300" in host.run("redis-cli config get timeout").stdout
+    assert "300" in host.run("/opt/rh/rh-redis5/root/usr/bin/redis-cli config get timeout").stdout

--- a/tasks/overwrites.yml
+++ b/tasks/overwrites.yml
@@ -21,7 +21,7 @@
 
 - name: Define redis_daemonize
   set_fact:
-    redis_daemonize: "{{ __redis_daemonize }}"
+    redis_daemonize: '{{ __redis_daemonize }}'
   when: redis_daemonize is not defined
 
 - name: Define redis_logfile

--- a/tasks/overwrites.yml
+++ b/tasks/overwrites.yml
@@ -14,4 +14,24 @@
     redis_conf_path: "{{ __redis_conf_path }}"
   when: redis_conf_path is not defined
 
+- name: Define redis_dbdir
+  set_fact:
+    redis_dbdir: "{{ __redis_dbdir }}"
+  when: redis_dbdir is not defined
+
+- name: Define redis_daemonize
+  set_fact:
+    redis_daemonize: "{{ __redis_daemonize }}"
+  when: redis_daemonize is not defined
+
+- name: Define redis_logfile
+  set_fact:
+    redis_logfile: "{{ __redis_logfile }}"
+  when: redis_logfile is not defined
+
+- name: Define redis_pidfile
+  set_fact:
+    redis_pidfile: "{{ __redis_pidfile }}"
+  when: redis_pidfile is not defined
+
 ...

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,8 +1,8 @@
 #jinja2: lstrip_blocks: True
 {{ ansible_managed | comment }}
 
-daemonize yes
-pidfile /var/run/redis/{{ redis_daemon }}.pid
+daemonize {{ redis_daemonize }}
+pidfile {{ redis_pidfile }}
 port {{ redis_port }}
 bind {{ redis_bind_interface }}
 {% if redis_unixsocket is defined and redis_unixsocket %}

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -1,7 +1,7 @@
 #jinja2: lstrip_blocks: True
 {{ ansible_managed | comment }}
 
-daemonize {{ redis_daemonize }}
+daemonize "{{ 'yes' if redis_daemonize | bool else 'no' }}"
 pidfile {{ redis_pidfile }}
 port {{ redis_port }}
 bind {{ redis_bind_interface }}

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -5,7 +5,7 @@ __redis_daemon: redis-server
 __redis_conf_path: /etc/redis/redis.conf
 
 __redis_dbdir: /var/lib/redis
-__redis_daemonize: yes
+__redis_daemonize: "yes"
 __redis_logfile: /var/log/redis/redis.log
 __redis_pidfile: /var/run/redis/redis-server.pid
 

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -4,4 +4,9 @@ __redis_packages:
 __redis_daemon: redis-server
 __redis_conf_path: /etc/redis/redis.conf
 
+__redis_dbdir: /var/lib/redis
+__redis_daemonize: "yes"
+__redis_logfile: /var/log/redis/redis.log
+__redis_pidfile: /var/run/redis_6379.pid
+
 ...

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -5,7 +5,7 @@ __redis_daemon: redis-server
 __redis_conf_path: /etc/redis/redis.conf
 
 __redis_dbdir: /var/lib/redis
-__redis_daemonize: "yes"
+__redis_daemonize: yes
 __redis_logfile: /var/log/redis/redis.log
 __redis_pidfile: /var/run/redis/redis-server.pid
 

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -7,6 +7,6 @@ __redis_conf_path: /etc/redis/redis.conf
 __redis_dbdir: /var/lib/redis
 __redis_daemonize: "yes"
 __redis_logfile: /var/log/redis/redis.log
-__redis_pidfile: /var/run/redis_6379.pid
+__redis_pidfile: /var/run/redis/redis-server.pid
 
 ...

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,7 +1,13 @@
 ---
 __redis_packages:
-  - redis
-__redis_daemon: redis
-__redis_conf_path: /etc/redis.conf
+  - rh-redis5
+__redis_daemon: rh-redis5-redis
+__redis_conf_path: /etc/opt/rh/rh-redis5/redis.conf
+
+# and configure overwrites.yml
+__redis_dbdir: /var/opt/rh/rh-redis5/lib/redis
+__redis_daemonize: "no"
+__redis_logfile: /var/opt/rh/rh-redis5/log/redis/redis.log
+__redis_pidfile: /var/opt/rh/rh-redis5/run/redis_6379.pid
 
 ...

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -4,9 +4,8 @@ __redis_packages:
 __redis_daemon: rh-redis5-redis
 __redis_conf_path: /etc/opt/rh/rh-redis5/redis.conf
 
-# and configure overwrites.yml
 __redis_dbdir: /var/opt/rh/rh-redis5/lib/redis
-__redis_daemonize: "no"
+__redis_daemonize: no
 __redis_logfile: /var/opt/rh/rh-redis5/log/redis/redis.log
 __redis_pidfile: /var/opt/rh/rh-redis5/run/redis_6379.pid
 

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -5,7 +5,7 @@ __redis_daemon: rh-redis5-redis
 __redis_conf_path: /etc/opt/rh/rh-redis5/redis.conf
 
 __redis_dbdir: /var/opt/rh/rh-redis5/lib/redis
-__redis_daemonize: no
+__redis_daemonize: "no"
 __redis_logfile: /var/opt/rh/rh-redis5/log/redis/redis.log
 __redis_pidfile: /var/opt/rh/rh-redis5/run/redis_6379.pid
 

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -5,7 +5,7 @@ __redis_daemon: rh-redis5-redis
 __redis_conf_path: /etc/opt/rh/rh-redis5/redis.conf
 
 __redis_dbdir: /var/opt/rh/rh-redis5/lib/redis
-__redis_daemonize: "no"
+__redis_daemonize: no
 __redis_logfile: /var/opt/rh/rh-redis5/log/redis/redis.log
 __redis_pidfile: /var/opt/rh/rh-redis5/run/redis_6379.pid
 


### PR DESCRIPTION
This changes the redis installation in CentOS 7 to the SCL package which provides a more up to date version (Redis version 5)
DONE:
- created new variables in `vars/{debian,redhat}.yml`
- removed variables from `defaults/main.yml`
- adjusted testing
- create handling for new variables in `tasks/overwrites.yml`
- update `templates/redis.conf.j2` to apply current default configuration for Redis 5 (also need to make sure this still works on Ubuntu 18.04)